### PR TITLE
Improvement: error type of App

### DIFF
--- a/src/main/kotlin/io/arrow/example/Application.kt
+++ b/src/main/kotlin/io/arrow/example/Application.kt
@@ -47,7 +47,7 @@ class ExampleApp(
         call.respondText("Hello World!")
       }
       get("/process") {
-        when (val result = either<OutgoingContent, List<Entry>> {
+        when (val result = either<BadRequest, List<Entry>> {
           val order = Either.catch { call.receive<Order>() }
             .mapLeft { badRequest(it.message ?: "Received an invalid order") }
             .bind()
@@ -62,7 +62,7 @@ class ExampleApp(
             badRequest("Following productIds weren't available: ${availability.joinToString { it.productId }}")
           }.bind()
         }) {
-          is Either.Left<OutgoingContent> ->
+          is Either.Left<BadRequest> ->
             call.respond(result.value)
           is Either.Right<List<Entry>> -> when (billing.processBilling(mapOf())) {
             BillingResponse.OK ->
@@ -78,7 +78,9 @@ class ExampleApp(
   }
 }
 
-private fun badRequest(message: String): OutgoingContent =
+typealias BadRequest = TextContent
+
+private fun badRequest(message: String): TextContent =
   TextContent(message, ContentType.Text.Plain, HttpStatusCode.BadRequest)
 
 @ExperimentalTime


### PR DESCRIPTION
This PR uses `OutgoingMessage` for the "error" type in the edge of Ktor.
It does so by mapping all independent domain errors into the `OutgoingContent` we want to send over the wire using `Ktor`.

From an architectural point of view I think this is fine, because the composition of domain functions is happening inside the Ktor edge. At the edgepoint we're "aware" of Ktor, and thus it's fine to use it's domain IMO.

If the composition of independent domain functions needs to be encoded in a "generic" (agnostic of Ktor) way, then it should define a new `sealed class/interface` of composed errors (or pray for union types into the lang faster).